### PR TITLE
Fix AAIA grounding for more than 2 agents

### DIFF
--- a/theories/frompaper/cstit/cstitexamples_3agents.txt
+++ b/theories/frompaper/cstit/cstitexamples_3agents.txt
@@ -1,0 +1,10 @@
+Name: Testing cstit with 3 agents
+Source:
+Comment: Some v. simple examples of  mult-agent cstit formulae, mostly about ensuring there is cake.
+Logic: cstit
+Author: Eleanor Turner
+----
+s1: []cake.
+s2: [1]cake.
+s3: [1][2]cake.
+s4: [1][2][3]cake.

--- a/theories/frompaper/cstit/cstitexamples_4agents.txt
+++ b/theories/frompaper/cstit/cstitexamples_4agents.txt
@@ -1,0 +1,11 @@
+Name: Testing cstit with 4 agents
+Source:
+Comment: Some v. simple examples of  mult-agent cstit formulae, mostly about ensuring there is cake.
+Logic: cstit
+Author: Eleanor Turner
+----
+s1: []cake.
+s2: [1]cake.
+s3: [1][2]cake.
+s4: [1][2][3]cake.
+s5: [1][2][3][4]cake.

--- a/theories/frompaper/dstit/dstit_party.txt
+++ b/theories/frompaper/dstit/dstit_party.txt
@@ -1,0 +1,10 @@
+Name: dstit party
+Source:
+Comment: 
+Logic: dstit
+Author: Eleanor Turner
+----
+s1: ~[]cake.
+s2: []water.
+s3: [1]cake.
+s4: [1]water.

--- a/xml_outputs/cstit/aaiabasic_post_translator_changes_040424.xml
+++ b/xml_outputs/cstit/aaiabasic_post_translator_changes_040424.xml
@@ -1,0 +1,786 @@
+<?xml version="1.0"?>
+<Ontology xmlns="http://www.w3.org/2002/07/owl#"
+     xml:base="aaiabasic_post.xml"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     ontologyIRI="aaiabasic_post.xml">
+    <Prefix name="" IRI="aaiabasic_post.xml#"/>
+    <Prefix name="dc" IRI="http://purl.org/dc/elements/1.1/"/>
+    <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
+    <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+    <Prefix name="xml" IRI="http://www.w3.org/XML/1998/namespace"/>
+    <Prefix name="xsd" IRI="http://www.w3.org/2001/XMLSchema#"/>
+    <Prefix name="rdfs" IRI="http://www.w3.org/2000/01/rdf-schema#"/>
+      <Declaration>
+        <Class abbreviatedIRI=":cake"/>
+    </Declaration>
+      <Declaration>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </Declaration>
+  <Declaration>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </Declaration>
+        <EquivalentClasses>
+            <Class abbreviatedIRI=":s1"/> 
+            <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectSomeValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s2"/> 
+            
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s3"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s4"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":EqivL"/> 
+            
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":EqivR"/> 
+            
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+        </EquivalentClasses>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </ReflexiveObjectProperty>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </ReflexiveObjectProperty>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </ReflexiveObjectProperty>
+
+        <SubObjectPropertyOf>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            <ObjectProperty abbreviatedIRI=":r"/>
+        </SubObjectPropertyOf>
+
+        <SubObjectPropertyOf>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            <ObjectProperty abbreviatedIRI=":r"/>
+        </SubObjectPropertyOf>
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                <Class abbreviatedIRI=":cake"/>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectSomeValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectSomeValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+
+    <SubClassOf>
+        
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectSomeValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+        
+        <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectSomeValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+        </ObjectSomeValuesFrom>
+    
+    </SubClassOf>
+    
+</Ontology>

--- a/xml_outputs/cstit/aaiabasic_pre_translator_changes_040424.xml
+++ b/xml_outputs/cstit/aaiabasic_pre_translator_changes_040424.xml
@@ -1,0 +1,783 @@
+<?xml version="1.0"?>
+<Ontology xmlns="http://www.w3.org/2002/07/owl#"
+     xml:base="aaiabasic_pre.xml"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     ontologyIRI="aaiabasic_pre.xml">
+    <Prefix name="" IRI="aaiabasic_pre.xml#"/>
+    <Prefix name="dc" IRI="http://purl.org/dc/elements/1.1/"/>
+    <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
+    <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+    <Prefix name="xml" IRI="http://www.w3.org/XML/1998/namespace"/>
+    <Prefix name="xsd" IRI="http://www.w3.org/2001/XMLSchema#"/>
+    <Prefix name="rdfs" IRI="http://www.w3.org/2000/01/rdf-schema#"/>
+      <Declaration>
+        <Class abbreviatedIRI=":cake"/>
+    </Declaration>
+      <Declaration>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </Declaration>
+        <EquivalentClasses>
+            <Class abbreviatedIRI=":s1"/> 
+            <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectSomeValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s2"/> 
+            
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s3"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s4"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":EqivL"/> 
+            
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":EqivR"/> 
+            
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+        </EquivalentClasses>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </ReflexiveObjectProperty>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </ReflexiveObjectProperty>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </ReflexiveObjectProperty>
+
+        <SubObjectPropertyOf>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            <ObjectProperty abbreviatedIRI=":r"/>
+        </SubObjectPropertyOf>
+
+        <SubObjectPropertyOf>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            <ObjectProperty abbreviatedIRI=":r"/>
+        </SubObjectPropertyOf>
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectSomeValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectSomeValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectSomeValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectSomeValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                <Class abbreviatedIRI=":cake"/>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectUnionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectUnionOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+</Ontology>

--- a/xml_outputs/cstit/cstitexamples.xml
+++ b/xml_outputs/cstit/cstitexamples.xml
@@ -1,0 +1,1197 @@
+<?xml version="1.0"?>
+<Ontology xmlns="http://www.w3.org/2002/07/owl#"
+     xml:base="cstitexamples.xml"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     ontologyIRI="cstitexamples.xml">
+    <Prefix name="" IRI="cstitexamples.xml#"/>
+    <Prefix name="dc" IRI="http://purl.org/dc/elements/1.1/"/>
+    <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
+    <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+    <Prefix name="xml" IRI="http://www.w3.org/XML/1998/namespace"/>
+    <Prefix name="xsd" IRI="http://www.w3.org/2001/XMLSchema#"/>
+    <Prefix name="rdfs" IRI="http://www.w3.org/2000/01/rdf-schema#"/>
+      <Declaration>
+        <Class abbreviatedIRI=":cake"/>
+    </Declaration>
+      <Declaration>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </Declaration>
+        <EquivalentClasses>
+            <Class abbreviatedIRI=":s1"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s2"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s3"/> 
+            
+        <ObjectIntersectionOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s4"/> 
+            
+        <ObjectIntersectionOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+        </ObjectSomeValuesFrom>
+        </ObjectIntersectionOf>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s5"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s6"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s7"/> 
+            
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":L2R"/> 
+            
+    <ObjectUnionOf>
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectUnionOf>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":R2L"/> 
+            
+    <ObjectUnionOf>
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectUnionOf>
+        </EquivalentClasses>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </ReflexiveObjectProperty>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </ReflexiveObjectProperty>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </ReflexiveObjectProperty>
+
+        <SubObjectPropertyOf>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            <ObjectProperty abbreviatedIRI=":r"/>
+        </SubObjectPropertyOf>
+
+        <SubObjectPropertyOf>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            <ObjectProperty abbreviatedIRI=":r"/>
+        </SubObjectPropertyOf>
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+        </ObjectSomeValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+        </ObjectSomeValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectUnionOf>
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectUnionOf>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectUnionOf>
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectUnionOf>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectUnionOf>
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectUnionOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectUnionOf>
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectUnionOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                <Class abbreviatedIRI=":cake"/>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectIntersectionOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectIntersectionOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectIntersectionOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+        </ObjectSomeValuesFrom>
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectIntersectionOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+        </ObjectSomeValuesFrom>
+        </ObjectIntersectionOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+        </ObjectSomeValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+        </ObjectSomeValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+        <ObjectIntersectionOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+        <ObjectIntersectionOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+        <ObjectIntersectionOf>
+            
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectIntersectionOf>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+        <ObjectIntersectionOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+        </ObjectSomeValuesFrom>
+        </ObjectIntersectionOf>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+        <ObjectIntersectionOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            <ObjectSomeValuesFrom>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+        </ObjectSomeValuesFrom>
+        </ObjectIntersectionOf>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectUnionOf>
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectUnionOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectUnionOf>
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectUnionOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectUnionOf>
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectUnionOf>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectUnionOf>
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectUnionOf>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n    ')
+            </ObjectSomeValuesFrom>
+    
+        </SubClassOf>
+        
+</Ontology>

--- a/xml_outputs/cstit/cstitexamples_3agents.xml
+++ b/xml_outputs/cstit/cstitexamples_3agents.xml
@@ -1,0 +1,1419 @@
+<?xml version="1.0"?>
+<Ontology xmlns="http://www.w3.org/2002/07/owl#"
+     xml:base="cstitexamples_3agents.xml"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     ontologyIRI="cstitexamples_3agents.xml">
+    <Prefix name="" IRI="cstitexamples_3agents.xml#"/>
+    <Prefix name="dc" IRI="http://purl.org/dc/elements/1.1/"/>
+    <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
+    <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+    <Prefix name="xml" IRI="http://www.w3.org/XML/1998/namespace"/>
+    <Prefix name="xsd" IRI="http://www.w3.org/2001/XMLSchema#"/>
+    <Prefix name="rdfs" IRI="http://www.w3.org/2000/01/rdf-schema#"/>
+      <Declaration>
+        <Class abbreviatedIRI=":cake"/>
+    </Declaration>
+      <Declaration>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+    </Declaration>
+  <Declaration>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </Declaration>
+  <Declaration>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </Declaration>
+        <EquivalentClasses>
+            <Class abbreviatedIRI=":s1"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s2"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s3"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s4"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </ReflexiveObjectProperty>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </ReflexiveObjectProperty>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </ReflexiveObjectProperty>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+    </ReflexiveObjectProperty>
+
+        <SubObjectPropertyOf>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            <ObjectProperty abbreviatedIRI=":r"/>
+        </SubObjectPropertyOf>
+
+        <SubObjectPropertyOf>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            <ObjectProperty abbreviatedIRI=":r"/>
+        </SubObjectPropertyOf>
+
+        <SubObjectPropertyOf>
+            <ObjectProperty abbreviatedIRI=":r_3"/>
+            <ObjectProperty abbreviatedIRI=":r"/>
+        </SubObjectPropertyOf>
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                <Class abbreviatedIRI=":cake"/>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+</Ontology>

--- a/xml_outputs/cstit/cstitexamples_4agents.xml
+++ b/xml_outputs/cstit/cstitexamples_4agents.xml
@@ -1,0 +1,3964 @@
+<?xml version="1.0"?>
+<Ontology xmlns="http://www.w3.org/2002/07/owl#"
+     xml:base="cstitexamples_4agents.xml"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     ontologyIRI="cstitexamples_4agents.xml">
+    <Prefix name="" IRI="cstitexamples_4agents.xml#"/>
+    <Prefix name="dc" IRI="http://purl.org/dc/elements/1.1/"/>
+    <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
+    <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+    <Prefix name="xml" IRI="http://www.w3.org/XML/1998/namespace"/>
+    <Prefix name="xsd" IRI="http://www.w3.org/2001/XMLSchema#"/>
+    <Prefix name="rdfs" IRI="http://www.w3.org/2000/01/rdf-schema#"/>
+      <Declaration>
+        <Class abbreviatedIRI=":cake"/>
+    </Declaration>
+      <Declaration>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </Declaration>
+  <Declaration>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+    </Declaration>
+  <Declaration>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+    </Declaration>
+  <Declaration>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </Declaration>
+        <EquivalentClasses>
+            <Class abbreviatedIRI=":s1"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s2"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s3"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s4"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <EquivalentClasses>
+            <Class abbreviatedIRI=":s5"/> 
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </EquivalentClasses>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r"/>
+    </ReflexiveObjectProperty>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+    </ReflexiveObjectProperty>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+    </ReflexiveObjectProperty>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+    </ReflexiveObjectProperty>
+    <SymmetricObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+    </SymmetricObjectProperty>
+    <TransitiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+    </TransitiveObjectProperty>
+    <ReflexiveObjectProperty>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+    </ReflexiveObjectProperty>
+
+        <SubObjectPropertyOf>
+            <ObjectProperty abbreviatedIRI=":r_1"/>
+            <ObjectProperty abbreviatedIRI=":r"/>
+        </SubObjectPropertyOf>
+
+        <SubObjectPropertyOf>
+            <ObjectProperty abbreviatedIRI=":r_2"/>
+            <ObjectProperty abbreviatedIRI=":r"/>
+        </SubObjectPropertyOf>
+
+        <SubObjectPropertyOf>
+            <ObjectProperty abbreviatedIRI=":r_3"/>
+            <ObjectProperty abbreviatedIRI=":r"/>
+        </SubObjectPropertyOf>
+
+        <SubObjectPropertyOf>
+            <ObjectProperty abbreviatedIRI=":r_4"/>
+            <ObjectProperty abbreviatedIRI=":r"/>
+        </SubObjectPropertyOf>
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            <Class abbreviatedIRI=":cake"/>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                <Class abbreviatedIRI=":cake"/>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                <Class abbreviatedIRI=":cake"/>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+        <ObjectComplementOf>
+            
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_1"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+        </ObjectComplementOf>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_4"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_3"/>
+                
+        <ObjectIntersectionOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_1"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+        
+        </ObjectIntersectionOf>
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+
+        <SubClassOf>
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r"/>
+                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+            </ObjectSomeValuesFrom>
+    
+            
+            <ObjectSomeValuesFrom>
+                <ObjectProperty abbreviatedIRI=":r_2"/>
+                ('r_1', '\n            <ObjectSomeValuesFrom>\n                <ObjectProperty abbreviatedIRI=":r_1"/>\n                
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_2"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_3"/>
+        
+    <ObjectAllValuesFrom>
+        <ObjectProperty abbreviatedIRI=":r_4"/>
+        <Class abbreviatedIRI=":cake"/>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>
+    </ObjectAllValuesFrom>\n            </ObjectSomeValuesFrom>\n        ')
+            </ObjectSomeValuesFrom>
+        
+        </SubClassOf>
+        
+</Ontology>


### PR DESCRIPTION
AAIA grounding wasn't looping through all agents correctly and was not producing schemas for more than 2 agents. i.e. for 3 agents, it would create AAIA_2 but not AAIA_1. This changes intends to fix this.